### PR TITLE
Fix pyrad.Client to work with more than FD_SETSIZE file descriptors

### DIFF
--- a/pyrad/tests/mock.py
+++ b/pyrad/tests/mock.py
@@ -90,7 +90,7 @@ class MockPoll:
         except KeyError:
             pass
 
-    def poll(self):
+    def poll(self, timeout=None):
         for result in self.results:
             yield result
         raise MockFinished

--- a/pyrad/tests/mock.py
+++ b/pyrad/tests/mock.py
@@ -79,10 +79,16 @@ class MockPoll:
     results = []
 
     def __init__(self):
-        self.registry = []
+        self.registry = {}
 
     def register(self, fd, options):
-        self.registry.append((fd, options))
+        self.registry[fd] = options
+
+    def unregister(self, fd):
+        try:
+            del self.registry[fd]
+        except KeyError:
+            pass
 
     def poll(self):
         for result in self.results:

--- a/pyrad/tests/testClient.py
+++ b/pyrad/tests/testClient.py
@@ -1,3 +1,4 @@
+import select
 import socket
 import unittest
 import six
@@ -8,6 +9,7 @@ from pyrad.packet import AcctPacket
 from pyrad.packet import AccessRequest
 from pyrad.packet import AccountingRequest
 from pyrad.tests.mock import MockPacket
+from pyrad.tests.mock import MockPoll
 from pyrad.tests.mock import MockSocket
 
 BIND_IP = "127.0.0.1"
@@ -56,6 +58,7 @@ class SocketTests(unittest.TestCase):
         self.orgsocket = socket.socket
         socket.socket = MockSocket
 
+
     def tearDown(self):
         socket.socket = self.orgsocket
 
@@ -74,6 +77,7 @@ class SocketTests(unittest.TestCase):
     def testBindClosesSocket(self):
         s = MockSocket(socket.AF_INET, socket.SOCK_DGRAM)
         self.client._socket = s
+        self.client._poll = MockPoll()
         self.client.bind((BIND_IP, BIND_PORT))
         self.assertEqual(s.closed, True)
 
@@ -146,6 +150,8 @@ class SocketTests(unittest.TestCase):
         self.client.retries = 1
         self.client.timeout = 1
         self.client._socket = MockSocket(1, 2, six.b("valid reply"))
+        self.client._poll = MockPoll()
+        MockPoll.results = [(1, select.POLLIN)]
         packet = MockPacket(AccountingRequest, verify=True)
         reply = self.client._SendPacket(packet, 432)
         self.failUnless(reply is packet.reply)
@@ -154,6 +160,7 @@ class SocketTests(unittest.TestCase):
         self.client.retries = 1
         self.client.timeout = 1
         self.client._socket = MockSocket(1, 2, six.b("invalid reply"))
+        MockPoll.results = [(1, select.POLLIN)]
         packet = MockPacket(AccountingRequest, verify=False)
         self.assertRaises(Timeout, self.client._SendPacket, packet, 432)
 

--- a/pyrad/tests/testProxy.py
+++ b/pyrad/tests/testProxy.py
@@ -33,7 +33,7 @@ class SocketTests(unittest.TestCase):
         self.failUnless(isinstance(self.proxy._proxyfd, MockSocket))
         self.assertEqual(list(self.proxy._fdmap.keys()), [1])
         self.assertEqual(self.proxy._poll.registry,
-                [(1, select.POLLIN | select.POLLPRI | select.POLLERR)])
+                {1: select.POLLIN | select.POLLPRI | select.POLLERR})
 
 
 class ProxyPacketHandlingTests(unittest.TestCase):

--- a/pyrad/tests/testServer.py
+++ b/pyrad/tests/testServer.py
@@ -109,7 +109,7 @@ class SocketTests(unittest.TestCase):
         self.server._poll = MockPoll()
         self.server._PrepareSockets()
 
-        self.assertEqual(self.server._poll.registry, [])
+        self.assertEqual(self.server._poll.registry, {})
         self.assertEqual(self.server._realauthfds, [])
         self.assertEqual(self.server._realacctfds, [])
 
@@ -121,8 +121,8 @@ class SocketTests(unittest.TestCase):
 
         self.assertEqual(list(self.server._fdmap.keys()), [12, 14])
         self.assertEqual(self.server._poll.registry,
-                [(12, select.POLLIN | select.POLLPRI | select.POLLERR),
-                 (14, select.POLLIN | select.POLLPRI | select.POLLERR)])
+                {12: select.POLLIN | select.POLLPRI | select.POLLERR,
+                 14: select.POLLIN | select.POLLPRI | select.POLLERR})
 
     def testPrepareSocketAcctFds(self):
         self.server._poll = MockPoll()
@@ -132,8 +132,8 @@ class SocketTests(unittest.TestCase):
 
         self.assertEqual(list(self.server._fdmap.keys()), [12, 14])
         self.assertEqual(self.server._poll.registry,
-                [(12, select.POLLIN | select.POLLPRI | select.POLLERR),
-                 (14, select.POLLIN | select.POLLPRI | select.POLLERR)])
+                {12: select.POLLIN | select.POLLPRI | select.POLLERR,
+                 14: select.POLLIN | select.POLLPRI | select.POLLERR})
 
 
 class AuthPacketHandlingTests(unittest.TestCase):


### PR DESCRIPTION
We've experienced an issue when using pyrad: when using it in a long-running application keeping a large number of TCP connections open, RADIUS authentication can fail with the following exception:

ValueError: filedescriptor out of range in select()

It turns out that using select.select() is not very feasible unless you can make sure that the file descriptor of the client is less than FD_SETSIZE (practically 1024, at least on Linux).