### PR TITLE
server: fix listen for CoAs without auth, neither acct , add runtime CoA+disconnect example

### DIFF
--- a/example/coa.py
+++ b/example/coa.py
@@ -3,12 +3,19 @@ from __future__ import print_function
 from pyrad.client import Client
 from pyrad import dictionary
 from pyrad import packet
+import sys
+
+if len(sys.argv) != 3:
+  print ("usage: coa.py {coa|dis} daemon-1234")
+  sys.exit(1)
 
 ADDRESS = "127.0.0.1"
 SECRET = b"Kah3choteereethiejeimaeziecumi"
 ATTRIBUTES = {
     "Acct-Session-Id": "1337"
 }
+
+ATTRIBUTES["NAS-Identifier"] = sys.argv[2]
 
 # create coa client
 client = Client(server=ADDRESS, secret=SECRET, dict=dictionary.Dictionary("dictionary"))
@@ -19,10 +26,14 @@ client.timeout = 30
 # create coa request packet
 attributes = {k.replace("-", "_"): ATTRIBUTES[k] for k in ATTRIBUTES}
 
-# create coa request
-request = client.CreateCoAPacket(**attributes)
-# create disconnect request
-# request = client.CreateCoAPacket(code=packet.DisconnectRequest, **attributes)
+if sys.argv[1] == "coa":
+    # create coa request
+    request = client.CreateCoAPacket(**attributes)
+elif sys.argv[1] == "dis":
+    # create disconnect request
+    request = client.CreateCoAPacket(code=packet.DisconnectRequest, **attributes)
+else:
+  sys.exit(1)
 
 # send request
 result = client.SendPacket(request)

--- a/pyrad/server.py
+++ b/pyrad/server.py
@@ -281,15 +281,17 @@ class Server(host.Host):
         :param  fd: socket to read packet from
         :type   fd: socket class instance
         """
-        if fd.fileno() in self._realauthfds:
+        if self.auth_enabled and fd.fileno() in self._realauthfds:
             pkt = self._GrabPacket(lambda data, s=self: s.CreateAuthPacket(packet=data), fd)
             self._HandleAuthPacket(pkt)
-        elif fd.fileno() in self._realacctfds:
+        elif self.acct_enabled and fd.fileno() in self._realacctfds:
             pkt = self._GrabPacket(lambda data, s=self: s.CreateAcctPacket(packet=data), fd)
             self._HandleAcctPacket(pkt)
-        else:
+        elif self.coa_enabled:
             pkt = self._GrabPacket(lambda data, s=self: s.CreateCoAPacket(packet=data), fd)
             self._HandleCoaPacket(pkt)
+        else:
+            raise ServerPacketError('Received packet for unknown handler')
 
     def Run(self):
         """Main loop.


### PR DESCRIPTION
When auth_enabled is False and acct_enabled is False, we cannot start
a listener for CoA only.

Fixes: db780ca1 ("add coa server support")
Fixes: 40c7eaba ("historics")