### PR TITLE
coa-client: emulate fake coa-client to test CoA proxies/forwarders

### DIFF
--- a/example/client-coa.py
+++ b/example/client-coa.py
@@ -1,0 +1,62 @@
+#!/usr/bin/python
+#
+# Copyright 6WIND, 2017
+#
+
+from __future__ import print_function
+from pyrad import dictionary, packet, server
+import sys
+import prctl
+
+class FakeCoA(server.Server):
+
+    def HandleCoaPacket(self, pkt):
+        """Accounting packet handler.
+        Function that is called when a valid
+        accounting packet has been received.
+
+        :param pkt: packet to process
+        :type  pkt: Packet class instance
+        """
+        print("Received a coa request %d" % pkt.code)
+        print("  Attributes: ")
+        for attr in pkt.keys():
+            print("  %s: %s" % (attr, pkt[attr]))
+
+        reply = self.CreateReplyPacket(pkt)
+        # try ACK or NACK
+        # reply.code = packet.CoANAK
+        reply.code = packet.CoAACK
+        self.SendReplyPacket(pkt.fd, reply)
+
+    def HandleDisconnectPacket(self, pkt):
+        print("Received a disconnect request %d" % pkt.code)
+        print("  Attributes: ")
+        for attr in pkt.keys():
+            print("  %s: %s" % (attr, pkt[attr]))
+
+        reply = self.CreateReplyPacket(pkt)
+        # try ACK or NACK
+        # reply.code = packet.DisconnectNAK
+        reply.code = packet.DisconnectACK
+        self.SendReplyPacket(pkt.fd, reply)
+
+if __name__ == '__main__':
+
+    prctl.set_name('radius-FakeCoA-client')
+
+    if len(sys.argv) != 2:
+        print ("usage: client-coa.py 3799")
+        sys.exit(1)
+
+    bindport=int(sys.argv[1])
+
+    # create server/coa only and read dictionary
+    # bind and listen only on 127.0.0.1:argv[1]
+    coa = FakeCoA(addresses=["127.0.0.1"], dict=dictionary.Dictionary("dictionary"), coaport=bindport, auth_enabled=False, acct_enabled=False, coa_enabled=True)
+
+    # add peers (address, secret, name)
+    coa.hosts["127.0.0.1"] = server.RemoteHost("127.0.0.1", b"Kah3choteereethiejeimaeziecumi", "localhost")
+
+    # start
+    coa.Run()

--- a/example/coa.py
+++ b/example/coa.py
@@ -3,12 +3,19 @@ from __future__ import print_function
 from pyrad.client import Client
 from pyrad import dictionary
 from pyrad import packet
+import sys
+
+if len(sys.argv) != 3:
+  print ("usage: coa.py {coa|dis} daemon-1234")
+  sys.exit(1)
 
 ADDRESS = "127.0.0.1"
 SECRET = b"Kah3choteereethiejeimaeziecumi"
 ATTRIBUTES = {
     "Acct-Session-Id": "1337"
 }
+
+ATTRIBUTES["NAS-Identifier"] = sys.argv[2]
 
 # create coa client
 client = Client(server=ADDRESS, secret=SECRET, dict=dictionary.Dictionary("dictionary"))
@@ -19,10 +26,14 @@ client.timeout = 30
 # create coa request packet
 attributes = {k.replace("-", "_"): ATTRIBUTES[k] for k in ATTRIBUTES}
 
-# create coa request
-request = client.CreateCoAPacket(**attributes)
-# create disconnect request
-# request = client.CreateCoAPacket(code=packet.DisconnectRequest, **attributes)
+if sys.argv[1] == "coa":
+    # create coa request
+    request = client.CreateCoAPacket(**attributes)
+elif sys.argv[1] == "dis":
+    # create disconnect request
+    request = client.CreateCoAPacket(code=packet.DisconnectRequest, **attributes)
+else:
+  sys.exit(1)
 
 # send request
 result = client.SendPacket(request)

--- a/pyrad/server.py
+++ b/pyrad/server.py
@@ -281,15 +281,17 @@ class Server(host.Host):
         :param  fd: socket to read packet from
         :type   fd: socket class instance
         """
-        if fd.fileno() in self._realauthfds:
+        if self.auth_enabled and fd.fileno() in self._realauthfds:
             pkt = self._GrabPacket(lambda data, s=self: s.CreateAuthPacket(packet=data), fd)
             self._HandleAuthPacket(pkt)
-        elif fd.fileno() in self._realacctfds:
+        elif self.acct_enabled and fd.fileno() in self._realacctfds:
             pkt = self._GrabPacket(lambda data, s=self: s.CreateAcctPacket(packet=data), fd)
             self._HandleAcctPacket(pkt)
-        else:
+        elif self.coa_enabled:
             pkt = self._GrabPacket(lambda data, s=self: s.CreateCoAPacket(packet=data), fd)
             self._HandleCoaPacket(pkt)
+        else:
+            raise ServerPacketError('Received packet for unknown handler')
 
     def Run(self):
         """Main loop.


### PR DESCRIPTION
We can launch multiple coa-client.py processes that listen on various UDP ports on a same local system. It is convenient to test a local CoA proxy that forwards to various CoA client.