### PR TITLE
Issue63 Add *.egg directories to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ docs/.build/
 pyrad.egg-info/
 *.pyc
 *__pycache__
+*.egg/


### PR DESCRIPTION
Without this, once you run tests with:
  python setup.py test

the dependency directories show up in git status, which is a tad
annoying.