### PR TITLE
Added support of tlv and integer64 attributes

### DIFF
--- a/pyrad/packet.py
+++ b/pyrad/packet.py
@@ -85,7 +85,7 @@ class Packet(dict):
         self.secret = secret
         if authenticator is not None and \
                 not isinstance(authenticator, six.binary_type):
-                    raise TypeError('authenticator must be a binary string')
+            raise TypeError('authenticator must be a binary string')
         self.authenticator = authenticator
 
         if 'dict' in attributes:
@@ -133,13 +133,8 @@ class Packet(dict):
             return (key, values)
 
         key, _, tag = key.partition(":")
-
         attr = self.dict.attributes[key]
-        if attr.vendor:
-            key = (self.dict.vendors.GetForward(attr.vendor), attr.code)
-        else:
-            key = attr.code
-
+        key = self._EncodeKey(key)
         if tag:
             tag = struct.pack('B', int(tag))
             if attr.type == "integer":
@@ -154,7 +149,7 @@ class Packet(dict):
             return key
 
         attr = self.dict.attributes[key]
-        if attr.vendor:
+        if attr.vendor and not attr.is_sub_attribute:  #sub attribute keys don't need vendor
             return (self.dict.vendors.GetForward(attr.vendor), attr.code)
         else:
             return attr.code
@@ -175,13 +170,20 @@ class Packet(dict):
         :param value: value
         :type value:  depends on type of attribute
         """
+        attr = self.dict.attributes[key]
+
         if isinstance(value, list):
             (key, value) = self._EncodeKeyValues(key, value)
-            self.setdefault(key, []).extend(value)
         else:
             (key, value) = self._EncodeKeyValues(key, [value])
-            value = value[0]
-            self.setdefault(key, []).append(value)
+
+        if attr.is_sub_attribute:
+            tlv = self.setdefault(self._EncodeKey(attr.parent.name), {})
+            encoded = tlv.setdefault(key, [])
+        else:
+            encoded = self.setdefault(key, [])
+
+        encoded.extend(value)
 
     def __getitem__(self, key):
         if not isinstance(key, six.string_types):
@@ -189,10 +191,19 @@ class Packet(dict):
 
         values = dict.__getitem__(self, self._EncodeKey(key))
         attr = self.dict.attributes[key]
-        res = []
-        for v in values:
-            res.append(self._DecodeValue(attr, v))
-        return res
+        if attr.type == 'tlv':  # return map from sub attribute code to its values
+            res = {}
+            for (sub_attr_key, sub_attr_val) in values.items():
+                sub_attr_name = attr.sub_attributes[sub_attr_key]
+                sub_attr = self.dict.attributes[sub_attr_name]
+                for v in sub_attr_val:
+                    res.setdefault(sub_attr_name, []).append(self._DecodeValue(sub_attr, v))
+            return res
+        else:
+            res = []
+            for v in values:
+                res.append(self._DecodeValue(attr, v))
+            return res
 
     def __contains__(self, key):
         try:
@@ -287,12 +298,46 @@ class Packet(dict):
 
         return struct.pack('!BB', key, (len(value) + 2)) + value
 
+    def _PktEncodeTlv(self, tlv_key, tlv_value):
+        tlv_attr = self.dict.attributes[self._DecodeKey(tlv_key)]
+        curr_avp = six.b('')
+        avps = []
+        max_sub_attribute_len = max(map(lambda item: len(item[1]), tlv_value.items()))
+        for i in range(max_sub_attribute_len):
+            sub_attr_encoding = six.b('')
+            for (code, datalst) in tlv_value.items():
+                if i < len(datalst):
+                    sub_attr_encoding += self._PktEncodeAttribute(code, datalst[i])
+            # split above 255. assuming len of one instance of all sub tlvs is lower than 255
+            if (len(sub_attr_encoding) + len(curr_avp)) < 245:
+                curr_avp += sub_attr_encoding
+            else:
+                avps.append(curr_avp)
+                curr_avp = sub_attr_encoding
+        avps.append(curr_avp)
+        tlv_avps = []
+        for avp in avps:
+            value = struct.pack('!BB', tlv_attr.code, (len(avp) + 2)) + avp
+            tlv_avps.append(value)
+        if tlv_attr.vendor:
+            vendor_avps = six.b('')
+            for avp in tlv_avps:
+                vendor_avps += struct.pack(
+                    '!BBL', 26, (len(avp) + 6),
+                    self.dict.vendors.GetForward(tlv_attr.vendor)
+                ) + avp
+            return vendor_avps
+        else:
+            return b''.join(tlv_avps)
+
     def _PktEncodeAttributes(self):
         result = six.b('')
         for (code, datalst) in self.items():
-            for data in datalst:
-                result += self._PktEncodeAttribute(code, data)
-
+            if self.dict.attributes[self._DecodeKey(code)].type == 'tlv':
+                result += self._PktEncodeTlv(code, datalst)
+            else:
+                for data in datalst:
+                    result += self._PktEncodeAttribute(code, data)
         return result
 
     def _PktDecodeVendorAttribute(self, data):
@@ -303,7 +348,14 @@ class Packet(dict):
 
         (vendor, type, length) = struct.unpack('!LBB', data[:6])[0:3]
 
-        tlvs = [((vendor, type), data[6:length+4])]
+        try:
+            if self.dict.attributes[self._DecodeKey((vendor, type))].type == 'tlv':
+                self._PktDecodeTlvAttribute((vendor, type), data[6:length + 4])
+                tlvs = []  # tlv is added to the packet inside _PktDecodeTlvAttribute
+            else:
+                tlvs = [((vendor, type), data[6:length + 4])]
+        except:
+            return [(26, data)]
 
         sumlength = 4 + length
         while len(data) > sumlength:
@@ -314,6 +366,16 @@ class Packet(dict):
             tlvs.append(((vendor, type), data[sumlength+2:sumlength+length]))
             sumlength += length
         return tlvs
+
+    def _PktDecodeTlvAttribute(self, code, data):
+
+        sub_attributes = self.setdefault(code, {})
+        loc = 0
+
+        while loc < len(data):
+            type, length = struct.unpack('!BB', data[loc:loc+2])[0:2]
+            sub_attributes.setdefault(type, []).append(data[loc+2:loc+length])
+            loc += length
 
     def DecodePacket(self, packet):
         """Initialize the object from raw packet data.  Decode a packet as
@@ -349,6 +411,8 @@ class Packet(dict):
             if key == 26:
                 for (key, value) in self._PktDecodeVendorAttribute(value):
                     self.setdefault(key, []).append(value)
+            elif self.dict.attributes[self._DecodeKey(key)].type == 'tlv':
+                self._PktDecodeTlvAttribute(key,value)
             else:
                 self.setdefault(key, []).append(value)
 

--- a/pyrad/tests/data/full
+++ b/pyrad/tests/data/full
@@ -10,15 +10,25 @@ VALUE      Test-Integer      Two     2
 VALUE      Test-Integer      Three   3
 VALUE      Test-Integer      Four    4
 
+ATTRIBUTE  Test-Tlv       4     tlv
+ATTRIBUTE  Test-Tlv-Str   4.1   string
+ATTRIBUTE  Test-Tlv-Int   4.2   integer
+
 VENDOR Simplon 16
 
 
 BEGIN-VENDOR Simplon
 ATTRIBUTE  Simplon-Number    1     integer
+ATTRIBUTE  Simplon-String    2     string
 
 VALUE      Simplon-Number     Zero    0
 VALUE      Simplon-Number     One     1
 VALUE      Simplon-Number     Two     2
 VALUE      Simplon-Number     Three   3
 VALUE      Simplon-Number     Four    4
+
+ATTRIBUTE  Simplon-Tlv       3     tlv
+ATTRIBUTE  Simplon-Tlv-Str   3.1   string
+ATTRIBUTE  Simplon-Tlv-Int   3.2   integer
+
 END-VENDOR Simplon

--- a/pyrad/tests/data/simple
+++ b/pyrad/tests/data/simple
@@ -8,4 +8,7 @@ ATTRIBUTE  Test-Ipv6-Address 5       ipv6addr
 ATTRIBUTE  Test-If-Id        6       ifid
 ATTRIBUTE  Test-Date         7       date
 ATTRIBUTE  Test-Abinary      8       abinary
-
+ATTRIBUTE  Test-Tlv          9       tlv
+ATTRIBUTE  Test-Tlv-Str      9.1     string
+ATTRIBUTE  Test-Tlv-Int      9.2     integer
+ATTRIBUTE  Test-Integer64    10      integer64

--- a/pyrad/tests/testDictionary.py
+++ b/pyrad/tests/testDictionary.py
@@ -15,12 +15,14 @@ class AttributeTests(unittest.TestCase):
         self.assertRaises(ValueError, Attribute, 'name', 'code', 'datatype')
 
     def testConstructionParameters(self):
-        attr = Attribute('name', 'code', 'integer', 'vendor')
+        attr = Attribute('name', 'code', 'integer', False, 'vendor')
         self.assertEqual(attr.name, 'name')
         self.assertEqual(attr.code, 'code')
         self.assertEqual(attr.type, 'integer')
+        self.assertEqual(attr.is_sub_attribute, False)
         self.assertEqual(attr.vendor, 'vendor')
         self.assertEqual(len(attr.values), 0)
+        self.assertEqual(len(attr.sub_attributes), 0)
 
     def testNamedConstructionParameters(self):
         attr = Attribute(name='name', code='code', datatype='integer',
@@ -32,7 +34,7 @@ class AttributeTests(unittest.TestCase):
         self.assertEqual(len(attr.values), 0)
 
     def testValues(self):
-        attr = Attribute('name', 'code', 'integer', 'vendor',
+        attr = Attribute('name', 'code', 'integer', False, 'vendor',
                 dict(pie='custard', shake='vanilla'))
         self.assertEqual(len(attr.values), 2)
         self.assertEqual(attr.values['shake'], 'vanilla')
@@ -63,6 +65,22 @@ class DictionaryInterfaceTests(unittest.TestCase):
 
 
 class DictionaryParsingTests(unittest.TestCase):
+
+    simple_dict_values = [
+        ('Test-String', 1, 'string'),
+        ('Test-Octets', 2, 'octets'),
+        ('Test-Integer', 3, 'integer'),
+        ('Test-Ip-Address', 4, 'ipaddr'),
+        ('Test-Ipv6-Address', 5, 'ipv6addr'),
+        ('Test-If-Id', 6, 'ifid'),
+        ('Test-Date', 7, 'date'),
+        ('Test-Abinary', 8, 'abinary'),
+        ('Test-Tlv', 9, 'tlv'),
+        ('Test-Tlv-Str', 1, 'string'),
+        ('Test-Tlv-Int', 2, 'integer'),
+        ('Test-Integer64', 10, 'integer64')
+    ]
+
     def setUp(self):
         self.path = os.path.join(home, 'tests', 'data')
         self.dict = Dictionary(os.path.join(self.path, 'simple'))
@@ -80,19 +98,8 @@ class DictionaryParsingTests(unittest.TestCase):
         self.assertEqual(len(dict), 2)
 
     def testParseSimpleDictionary(self):
-        self.assertEqual(len(self.dict), 8)
-        values = [
-                ('Test-String', 1, 'string'),
-                ('Test-Octets', 2, 'octets'),
-                ('Test-Integer', 3, 'integer'),
-                ('Test-Ip-Address', 4, 'ipaddr'),
-                ('Test-Ipv6-Address', 5, 'ipv6addr'),
-                ('Test-If-Id', 6, 'ifid'),
-                ('Test-Date', 7, 'date'),
-                ('Test-Abinary', 8, 'abinary'),
-                ]
-
-        for (attr, code, type) in values:
+        self.assertEqual(len(self.dict),len(self.simple_dict_values))
+        for (attr, code, type) in self.simple_dict_values:
             attr = self.dict[attr]
             self.assertEqual(attr.code, code)
             self.assertEqual(attr.type, type)
@@ -163,6 +170,15 @@ class DictionaryParsingTests(unittest.TestCase):
                     self.dict['Test-Integer'].values['Value-Six']),
                 5)
 
+    def testInteger64ValueParsing(self):
+        self.assertEqual(len(self.dict['Test-Integer64'].values), 0)
+        self.dict.ReadDictionary(StringIO('VALUE Test-Integer64 Value-Six 5'))
+        self.assertEqual(len(self.dict['Test-Integer64'].values), 1)
+        self.assertEqual(
+                DecodeAttr('integer64',
+                    self.dict['Test-Integer64'].values['Value-Six']),
+                5)
+
     def testStringValueParsing(self):
         self.assertEqual(len(self.dict['Test-String'].values), 0)
         self.dict.ReadDictionary(StringIO(
@@ -172,6 +188,27 @@ class DictionaryParsingTests(unittest.TestCase):
                 DecodeAttr('string',
                     self.dict['Test-String'].values['Value-Custard']),
                 'custardpie')
+
+    def testTlvParsing(self):
+        self.assertEqual(len(self.dict['Test-Tlv'].sub_attributes), 2)
+        self.assertEqual(self.dict['Test-Tlv'].sub_attributes, {1:'Test-Tlv-Str', 2: 'Test-Tlv-Int'})
+
+    def testSubTlvParsing(self):
+        for (attr, _, _) in self.simple_dict_values:
+            if attr.startswith('Test-Tlv-'):
+                self.assertEqual(self.dict[attr].is_sub_attribute, True)
+                self.assertEqual(self.dict[attr].parent, self.dict['Test-Tlv'])
+            else:
+                self.assertEqual(self.dict[attr].is_sub_attribute, False)
+                self.assertEqual(self.dict[attr].parent, None)
+
+        # tlv with vendor
+        full_dict = Dictionary(os.path.join(self.path, 'full'))
+        self.assertEqual(full_dict['Simplon-Tlv-Str'].is_sub_attribute, True)
+        self.assertEqual(full_dict['Simplon-Tlv-Str'].parent, full_dict['Simplon-Tlv'])
+        self.assertEqual(full_dict['Simplon-Tlv-Int'].is_sub_attribute, True)
+        self.assertEqual(full_dict['Simplon-Tlv-Int'].parent, full_dict['Simplon-Tlv'])
+
 
     def testVenderTooFewColumnsError(self):
         try:
@@ -188,7 +225,7 @@ class DictionaryParsingTests(unittest.TestCase):
         self.assertEqual(self.dict.vendors['Simplon'], 42)
         self.dict.ReadDictionary(StringIO(
                         'ATTRIBUTE Test-Type 1 integer Simplon'))
-        self.assertEquals(self.dict.attrindex['Test-Type'], (42, 1))
+        self.assertEqual(self.dict.attrindex['Test-Type'], (42, 1))
 
     def testVendorOptionError(self):
         self.assertRaises(ParseError, self.dict.ReadDictionary,
@@ -243,7 +280,7 @@ class DictionaryParsingTests(unittest.TestCase):
                         'VENDOR Simplon 42\n'
                         'BEGIN-VENDOR Simplon\n'
                         'ATTRIBUTE Test-Type 1 integer'))
-        self.assertEquals(self.dict.attrindex['Test-Type'], (42, 1))
+        self.assertEqual(self.dict.attrindex['Test-Type'], (42, 1))
 
     def testEndVendorUnknownVendor(self):
         try:
@@ -270,7 +307,7 @@ class DictionaryParsingTests(unittest.TestCase):
                         'BEGIN-VENDOR Simplon\n'
                         'END-VENDOR Simplon\n'
                         'ATTRIBUTE Test-Type 1 integer'))
-        self.assertEquals(self.dict.attrindex['Test-Type'], 1)
+        self.assertEqual(self.dict.attrindex['Test-Type'], 1)
 
     def testInclude(self):
         try:
@@ -290,14 +327,14 @@ class DictionaryParsingTests(unittest.TestCase):
                 'VENDOR Simplon 42\n'))
         for _ in f:
             pass
-        self.assertEquals(f.File(), '')
-        self.assertEquals(f.Line(), -1)
+        self.assertEqual(f.File(), '')
+        self.assertEqual(f.Line(), -1)
 
     def testDictFileParseError(self):
         tmpdict = Dictionary()
         try:
             tmpdict.ReadDictionary(os.path.join(self.path, 'dictfiletest'))
         except ParseError as e:
-            self.assertEquals('dictfiletest' in str(e), True)
+            self.assertEqual('dictfiletest' in str(e), True)
         else:
             self.fail()

--- a/pyrad/tests/testPacket.py
+++ b/pyrad/tests/testPacket.py
@@ -9,7 +9,7 @@ from pyrad.dictionary import Dictionary
 class UtilityTests(unittest.TestCase):
     def testGenerateID(self):
         id = packet.CreateID()
-        self.failUnless(isinstance(id, int))
+        self.assertTrue(isinstance(id, int))
         newid = packet.CreateID()
         self.assertNotEqual(id, newid)
 
@@ -23,9 +23,9 @@ class PacketConstructionTests(unittest.TestCase):
 
     def testBasicConstructor(self):
         pkt = self.klass()
-        self.failUnless(isinstance(pkt.code, int))
-        self.failUnless(isinstance(pkt.id, int))
-        self.failUnless(isinstance(pkt.secret, six.binary_type))
+        self.assertTrue(isinstance(pkt.code, int))
+        self.assertTrue(isinstance(pkt.id, int))
+        self.assertTrue(isinstance(pkt.secret, six.binary_type))
 
     def testNamedConstructor(self):
         pkt = self.klass(code=26, id=38, secret=six.b('secret'),
@@ -39,19 +39,27 @@ class PacketConstructionTests(unittest.TestCase):
 
     def testConstructWithDictionary(self):
         pkt = self.klass(dict=self.dict)
-        self.failUnless(pkt.dict is self.dict)
+        self.assertTrue(pkt.dict is self.dict)
 
     def testConstructorIgnoredParameters(self):
         marker = []
         pkt = self.klass(fd=marker)
-        self.failIf(getattr(pkt, 'fd', None) is marker)
+        self.assertFalse(getattr(pkt, 'fd', None) is marker)
 
     def testSecretMustBeBytestring(self):
         self.assertRaises(TypeError, self.klass, secret=six.u('secret'))
 
     def testConstructorWithAttributes(self):
-        pkt = self.klass(dict=self.dict, Test_String='this works')
+        pkt = self.klass(**{'Test-String' :'this works', 'dict' : self.dict})
         self.assertEqual(pkt['Test-String'], ['this works'])
+
+    def testConstructorWithTlvAttribute(self):
+        pkt = self.klass(**{
+            'Test-Tlv-Str': 'this works',
+            'Test-Tlv-Int': 10,
+            'dict': self.dict
+        })
+        self.assertEqual(pkt['Test-Tlv'], {'Test-Tlv-Str': ['this works'], 'Test-Tlv-Int' : [10]} )
 
 
 class PacketTests(unittest.TestCase):
@@ -62,7 +70,7 @@ class PacketTests(unittest.TestCase):
                 authenticator=six.b('01234567890ABCDEF'), dict=self.dict)
 
     def testCreateReply(self):
-        reply = self.packet.CreateReply(Test_Integer=10)
+        reply = self.packet.CreateReply(**{'Test-Integer' : 10})
         self.assertEqual(reply.id, self.packet.id)
         self.assertEqual(reply.secret, self.packet.secret)
         self.assertEqual(reply.authenticator, self.packet.authenticator)
@@ -94,9 +102,9 @@ class PacketTests(unittest.TestCase):
     def testRawAttributeAccess(self):
         marker = [six.b('')]
         self.packet[1] = marker
-        self.failUnless(self.packet[1] is marker)
+        self.assertTrue(self.packet[1] is marker)
         self.packet[(16, 1)] = marker
-        self.failUnless(self.packet[(16, 1)] is marker)
+        self.assertTrue(self.packet[(16, 1)] is marker)
 
     def testHasKey(self):
         self.assertEqual(self.packet.has_key('Test-String'), False)
@@ -130,7 +138,7 @@ class PacketTests(unittest.TestCase):
 
     def testCreateAuthenticator(self):
         a = packet.Packet.CreateAuthenticator()
-        self.failUnless(isinstance(a, six.binary_type))
+        self.assertTrue(isinstance(a, six.binary_type))
         self.assertEqual(len(a), 16)
 
         b = packet.Packet.CreateAuthenticator()
@@ -138,7 +146,7 @@ class PacketTests(unittest.TestCase):
 
     def testGenerateID(self):
         id = self.packet.CreateID()
-        self.failUnless(isinstance(id, int))
+        self.assertTrue(isinstance(id, int))
         newid = self.packet.CreateID()
         self.assertNotEqual(id, newid)
 
@@ -176,15 +184,48 @@ class PacketTests(unittest.TestCase):
                 encode((1, 2), six.b('value')),
                 six.b('\x1a\x0d\x00\x00\x00\x01\x02\x07value'))
 
+    def testPktEncodeTlvAttribute(self):
+        encode = self.packet._PktEncodeTlv
+
+        # Encode a normal tlv attribute
+        self.assertEqual(
+                encode(4, {1:[six.b('value')], 2:[six.b('\x00\x00\x00\x02')]}),
+                six.b('\x04\x0f\x01\x07value\x02\x06\x00\x00\x00\x02'))
+
+        # Encode a normal tlv attribute with several sub attribute instances
+        self.assertEqual(
+                encode(4, {1:[six.b('value'), six.b('other')], 2:[six.b('\x00\x00\x00\x02')]}),
+                six.b('\x04\x16\x01\x07value\x02\x06\x00\x00\x00\x02\x01\x07other'))
+        # Encode a vendor tlv attribute
+        self.assertEqual(
+                encode((16, 3), {1:[six.b('value')], 2:[six.b('\x00\x00\x00\x02')]}),
+                six.b('\x1a\x15\x00\x00\x00\x10\x03\x0f\x01\x07value\x02\x06\x00\x00\x00\x02'))
+
+    def testPktEncodeLongTlvAttribute(self):
+        encode = self.packet._PktEncodeTlv
+
+        long_str = 'a' * 245
+        # Encode a long tlv attribute - check it is split between AVPs
+        self.assertEqual(
+                encode(4, {1:[six.b('value'), six.b(long_str)], 2:[six.b('\x00\x00\x00\x02')]}),
+                six.b('\x04\x0f\x01\x07value\x02\x06\x00\x00\x00\x02\x04\xf9\x01\xf7' + long_str))
+
+        # Encode a long vendor tlv attribute
+        first_avp = '\x1a\x15\x00\x00\x00\x10\x03\x0f\x01\x07value\x02\x06\x00\x00\x00\x02'
+        second_avp = '\x1a\xff\x00\x00\x00\x10\x03\xf9\x01\xf7' + long_str
+        self.assertEqual(
+                encode((16, 3), {1:[six.b('value'), six.b(long_str)], 2:[six.b('\x00\x00\x00\x02')]}),
+                six.b(first_avp + second_avp))
+
     def testPktEncodeAttributes(self):
         self.packet[1] = [six.b('value')]
         self.assertEqual(self.packet._PktEncodeAttributes(),
                 six.b('\x01\x07value'))
 
         self.packet.clear()
-        self.packet[(1, 2)] = [six.b('value')]
+        self.packet[(16, 2)] = [six.b('value')]
         self.assertEqual(self.packet._PktEncodeAttributes(),
-                six.b('\x1a\x0d\x00\x00\x00\x01\x02\x07value'))
+                six.b('\x1a\x0d\x00\x00\x00\x10\x02\x07value'))
 
         self.packet.clear()
         self.packet[1] = [six.b('one'), six.b('two'), six.b('three')]
@@ -193,10 +234,10 @@ class PacketTests(unittest.TestCase):
 
         self.packet.clear()
         self.packet[1] = [six.b('value')]
-        self.packet[(1, 2)] = [six.b('value')]
+        self.packet[(16, 2)] = [six.b('value')]
         self.assertEqual(
                 self.packet._PktEncodeAttributes(),
-                six.b('\x1a\x0d\x00\x00\x00\x01\x02\x07value\x01\x07value'))
+                six.b('\x01\x07value\x1a\x0d\x00\x00\x00\x10\x02\x07value'))
 
     def testPktDecodeVendorAttribute(self):
         decode = self.packet._PktDecodeVendorAttribute
@@ -212,14 +253,31 @@ class PacketTests(unittest.TestCase):
 
         # Proper RFC2865 recommended form
         self.assertEqual(
-                decode(six.b('\x00\x00\x00\x01\x02\x07value')),
-                [((1, 2), six.b('value'))])
+                decode(six.b('\x00\x00\x00\x10\x02\x07value')),
+                [((16, 2), six.b('value'))])
+
+    def testPktDecodeTlvAttribute(self):
+        decode = self.packet._PktDecodeTlvAttribute
+
+        decode(4,six.b('\x01\x07value'))
+        self.assertEqual(self.packet[4], {1: [six.b('value')]})
+
+        #add another instance of the same sub attribute
+        decode(4,six.b('\x01\x07other'))
+        self.assertEqual(self.packet[4], {1: [six.b('value'), six.b('other')]})
+
+        #add a different sub attribute
+        decode(4,six.b('\x02\x07\x00\x00\x00\x01'))
+        self.assertEqual(self.packet[4], {
+            1: [six.b('value'), six.b('other')],
+            2: [six.b('\x00\x00\x00\x01')]
+        })
 
     def testDecodePacketWithEmptyPacket(self):
         try:
             self.packet.DecodePacket(six.b(''))
         except packet.PacketError as e:
-            self.failUnless('header is corrupt' in str(e))
+            self.assertTrue('header is corrupt' in str(e))
         else:
             self.fail()
 
@@ -227,7 +285,7 @@ class PacketTests(unittest.TestCase):
         try:
             self.packet.DecodePacket(six.b('\x00\x00\x00\x001234567890123456'))
         except packet.PacketError as e:
-            self.failUnless('invalid length' in str(e))
+            self.assertTrue('invalid length' in str(e))
         else:
             self.fail()
 
@@ -235,7 +293,7 @@ class PacketTests(unittest.TestCase):
         try:
             self.packet.DecodePacket(six.b('\x00\x00\x24\x00') + (0x2400 - 4) * six.b('X'))
         except packet.PacketError as e:
-            self.failUnless('too long' in str(e))
+            self.assertTrue('too long' in str(e))
         else:
             self.fail()
 
@@ -244,7 +302,7 @@ class PacketTests(unittest.TestCase):
             self.packet.DecodePacket(
                     six.b('\x01\x02\x00\x151234567890123456\x00'))
         except packet.PacketError as e:
-            self.failUnless('header is corrupt' in str(e))
+            self.assertTrue('header is corrupt' in str(e))
         else:
             self.fail()
 
@@ -260,30 +318,49 @@ class PacketTests(unittest.TestCase):
             self.packet.DecodePacket(
                     six.b('\x01\x02\x00\x161234567890123456\x00\x01'))
         except packet.PacketError as e:
-            self.failUnless('too small' in str(e))
+            self.assertTrue('too small' in str(e))
         else:
             self.fail()
 
     def testDecodePacketWithEmptyAttribute(self):
         self.packet.DecodePacket(
-                six.b('\x01\x02\x00\x161234567890123456\x00\x02'))
-        self.assertEqual(self.packet[0], [six.b('')])
+                six.b('\x01\x02\x00\x161234567890123456\x01\x02'))
+        self.assertEqual(self.packet[1], [six.b('')])
 
     def testDecodePacketWithAttribute(self):
         self.packet.DecodePacket(
-            six.b('\x01\x02\x00\x1b1234567890123456\x00\x07value'))
-        self.assertEqual(self.packet[0], [six.b('value')])
+            six.b('\x01\x02\x00\x1b1234567890123456\x01\x07value'))
+        self.assertEqual(self.packet[1], [six.b('value')])
+
+    def testDecodePacketWithTlvAttribute(self):
+        self.packet.DecodePacket(
+            six.b('\x01\x02\x00\x1d1234567890123456\x04\x09\x01\x07value'))
+        self.assertEqual(self.packet[4], {1:[six.b('value')]})
+
+    def testDecodePacketWithVendorTlvAttribute(self):
+        self.packet.DecodePacket(
+            six.b('\x01\x02\x00\x231234567890123456\x1a\x0f\x00\x00\x00\x10\x03\x09\x01\x07value'))
+        self.assertEqual(self.packet[(16,3)], {1:[six.b('value')]})
+
+    def testDecodePacketWithTlvAttributeWith2SubAttributes(self):
+        self.packet.DecodePacket(
+            six.b('\x01\x02\x00\x231234567890123456\x04\x0f\x01\x07value\x02\x06\x00\x00\x00\x09'))
+        self.assertEqual(self.packet[4], {1:[six.b('value')], 2:[six.b('\x00\x00\x00\x09')]})
+
+    def testDecodePacketWithSplitTlvAttribute(self):
+        self.packet.DecodePacket(
+            six.b('\x01\x02\x00\x251234567890123456\x04\x09\x01\x07value\x04\x09\x02\x06\x00\x00\x00\x09'))
+        self.assertEqual(self.packet[4], {1:[six.b('value')], 2:[six.b('\x00\x00\x00\x09')]})
 
     def testDecodePacketWithMultiValuedAttribute(self):
         self.packet.DecodePacket(
-            six.b('\x01\x02\x00\x1e1234567890123456\x00\x05one\x00\x05two'))
-        self.assertEqual(self.packet[0], [six.b('one'), six.b('two')])
+            six.b('\x01\x02\x00\x1e1234567890123456\x01\x05one\x01\x05two'))
+        self.assertEqual(self.packet[1], [six.b('one'), six.b('two')])
 
     def testDecodePacketWithTwoAttributes(self):
         self.packet.DecodePacket(
-            six.b('\x01\x02\x00\x1e1234567890123456\x00\x05one\x01\x05two'))
-        self.assertEqual(self.packet[0], [six.b('one')])
-        self.assertEqual(self.packet[1], [six.b('two')])
+            six.b('\x01\x02\x00\x1e1234567890123456\x01\x05one\x01\x05two'))
+        self.assertEqual(self.packet[1], [six.b('one'), six.b('two')])
 
     def testDecodePacketWithVendorAttribute(self):
         self.packet.DecodePacket(
@@ -297,12 +374,12 @@ class PacketTests(unittest.TestCase):
         self.assertEqual(self.packet._EncodeKey(1), 1)
 
     def testAddAttribute(self):
-        self.packet.AddAttribute(1, 1)
-        self.assertEqual(dict.__getitem__(self.packet, 1), [1])
-        self.packet.AddAttribute(1, 1)
-        self.assertEqual(dict.__getitem__(self.packet, 1), [1, 1])
-        self.packet.AddAttribute(1, [2, 3])
-        self.assertEqual(dict.__getitem__(self.packet, 1), [1, 1, 2, 3])
+        self.packet.AddAttribute('Test-String', '1')
+        self.assertEqual(self.packet['Test-String'], ['1'])
+        self.packet.AddAttribute('Test-String', '1')
+        self.assertEqual(self.packet['Test-String'], ['1', '1'])
+        self.packet.AddAttribute('Test-String', ['2', '3'])
+        self.assertEqual(self.packet['Test-String'], ['1', '1', '2', '3'])
 
 class AuthPacketConstructionTests(PacketConstructionTests):
     klass = packet.AuthPacket
@@ -320,7 +397,7 @@ class AuthPacketTests(unittest.TestCase):
                 authenticator=six.b('01234567890ABCDEF'), dict=self.dict)
 
     def testCreateReply(self):
-        reply = self.packet.CreateReply(Test_Integer=10)
+        reply = self.packet.CreateReply(**{'Test-Integer' : 10})
         self.assertEqual(reply.code, packet.AccessAccept)
         self.assertEqual(reply.id, self.packet.id)
         self.assertEqual(reply.secret, self.packet.secret)
@@ -334,12 +411,12 @@ class AuthPacketTests(unittest.TestCase):
     def testRequestPacketCreatesAuthenticator(self):
         self.packet.authenticator = None
         self.packet.RequestPacket()
-        self.failUnless(self.packet.authenticator is not None)
+        self.assertTrue(self.packet.authenticator is not None)
 
     def testRequestPacketCreatesID(self):
         self.packet.id = None
         self.packet.RequestPacket()
-        self.failUnless(self.packet.id is not None)
+        self.assertTrue(self.packet.id is not None)
 
     def testPwCryptEmptyPassword(self):
         self.assertEqual(self.packet.PwCrypt(''), six.b(''))
@@ -351,7 +428,7 @@ class AuthPacketTests(unittest.TestCase):
     def testPwCryptSetsAuthenticator(self):
         self.packet.authenticator = None
         self.packet.PwCrypt(six.u(''))
-        self.failUnless(self.packet.authenticator is not None)
+        self.assertTrue(self.packet.authenticator is not None)
 
     def testPwDecryptEmptyPassword(self):
         self.assertEqual(self.packet.PwDecrypt(six.b('')), six.u(''))
@@ -384,7 +461,7 @@ class AcctPacketTests(unittest.TestCase):
                 authenticator=six.b('01234567890ABCDEF'), dict=self.dict)
 
     def testCreateReply(self):
-        reply = self.packet.CreateReply(Test_Integer=10)
+        reply = self.packet.CreateReply(**{'Test-Integer' : 10})
         self.assertEqual(reply.code, packet.AccountingResponse)
         self.assertEqual(reply.id, self.packet.id)
         self.assertEqual(reply.secret, self.packet.secret)
@@ -410,4 +487,4 @@ class AcctPacketTests(unittest.TestCase):
     def testRequestPacketSetsId(self):
         self.packet.id = None
         self.packet.RequestPacket()
-        self.failUnless(self.packet.id is not None)
+        self.assertTrue(self.packet.id is not None)

--- a/pyrad/tests/testTools.py
+++ b/pyrad/tests/testTools.py
@@ -28,6 +28,11 @@ class EncodingTests(unittest.TestCase):
     def testIntegerEncoding(self):
         self.assertEqual(tools.EncodeInteger(0x01020304), six.b('\x01\x02\x03\x04'))
 
+    def testInteger64Encoding(self):
+        self.assertEqual(
+            tools.EncodeInteger64(0xFFFFFFFFFFFFFFFF), six.b('\xff' * 8)
+        )
+
     def testUnsignedIntegerEncoding(self):
         self.assertEqual(tools.EncodeInteger(0xFFFFFFFF), six.b('\xff\xff\xff\xff'))
 
@@ -60,6 +65,11 @@ class EncodingTests(unittest.TestCase):
                 tools.DecodeInteger(six.b('\x01\x02\x03\x04')),
                 0x01020304)
 
+    def testInteger64Decoding(self):
+        self.assertEqual(
+            tools.DecodeInteger64(six.b('\xff' * 8)), 0xFFFFFFFFFFFFFFFF
+        )
+
     def testDateDecoding(self):
         self.assertEqual(
                 tools.DecodeDate(six.b('\x01\x02\x03\x04')),
@@ -87,6 +97,9 @@ class EncodingTests(unittest.TestCase):
         self.assertEqual(
                 tools.EncodeAttr('date', 0x01020304),
                 six.b('\x01\x02\x03\x04'))
+        self.assertEqual(
+                tools.EncodeAttr('integer64', 0xFFFFFFFFFFFFFFFF),
+                six.b('\xff'*8))
 
     def testDecodeFunction(self):
         self.assertEqual(
@@ -101,6 +114,9 @@ class EncodingTests(unittest.TestCase):
         self.assertEqual(
                 tools.DecodeAttr('integer', six.b('\x01\x02\x03\x04')),
                 0x01020304)
+        self.assertEqual(
+                tools.DecodeAttr('integer64', six.b('\xff'*8)),
+                0xFFFFFFFFFFFFFFFF)
         self.assertEqual(
                 tools.DecodeAttr('date', six.b('\x01\x02\x03\x04')),
                 0x01020304)

--- a/pyrad/tools.py
+++ b/pyrad/tools.py
@@ -125,6 +125,12 @@ def EncodeInteger(num, format='!I'):
         raise TypeError('Can not encode non-integer as integer')
     return struct.pack(format, num)
 
+def EncodeInteger64(num, format='!Q'):
+    try:
+        num = int(num)
+    except:
+        raise TypeError('Can not encode non-integer as integer64')
+    return struct.pack(format, num)
 
 def EncodeDate(num):
     if not isinstance(num, int):
@@ -166,6 +172,8 @@ def DecodeAscendBinary(str):
 def DecodeInteger(num, format='!I'):
     return (struct.unpack(format, num))[0]
 
+def DecodeInteger64(num, format='!Q'):
+    return (struct.unpack(format, num))[0]
 
 def DecodeDate(num):
     return (struct.unpack('!I', num))[0]
@@ -194,6 +202,8 @@ def EncodeAttr(datatype, value):
         return EncodeInteger(value, '!B')
     elif datatype == 'date':
         return EncodeDate(value)
+    elif datatype == 'integer64':
+        return EncodeInteger64(value)
     else:
         raise ValueError('Unknown attribute type %s' % datatype)
 
@@ -221,5 +231,7 @@ def DecodeAttr(datatype, value):
         return DecodeInteger(value, '!B')
     elif datatype == 'date':
         return DecodeDate(value)
+    elif datatype == 'integer64':
+        return DecodeInteger64(value)
     else:
         raise ValueError('Unknown attribute type %s' % datatype)


### PR DESCRIPTION
Supporting tlv attributes and integer64 attributes.
Tlvs are containers of other attributes, and are implemented as a map from attribute code to list of the encoded attributes.
When a TLV is encoded it is split when it is too big (larger than 255 bytes).
The encoding of a TLV encodes each instance of sub attributes together (the 1st instance of all sub attributes is sequential, the 2nd instance and so on...).