### PR TITLE
DecodeIPv6Prefix and DecodeIPv6Addres function fix, ValueError zero length field name in format

### DIFF
--- a/pyrad/tools.py
+++ b/pyrad/tools.py
@@ -149,13 +149,13 @@ def DecodeAddress(addr):
 
 def DecodeIPv6Prefix(addr):
     addr = addr + b'\x00' * (18-len(addr))
-    _, length, prefix = ':'.join(map('{:x}'.format, struct.unpack('!BB'+'H'*8, addr))).split(":", 2)
+    _, length, prefix = ':'.join(map('{0:x}'.format, struct.unpack('!BB'+'H'*8, addr))).split(":", 2)
     return str(IPNetwork("%s/%s" % (prefix, int(length, 16))))
 
 
 def DecodeIPv6Address(addr):
     addr = addr + b'\x00' * (16-len(addr))
-    prefix = ':'.join(map('{:x}'.format, struct.unpack('!'+'H'*8, addr)))
+    prefix = ':'.join(map('{0:x}'.format, struct.unpack('!'+'H'*8, addr)))
     return str(IPAddress(prefix))
 
 


### PR DESCRIPTION
```
>>> def DecodeIPv6Prefix(addr):
...     addr = addr + b'\x00' * (18-len(addr))
...     _, length, prefix = ':'.join(map('{0:x}'.format, struct.unpack('!BB'+'H'*8, addr))).split(":", 2)
...     return str(IPNetwork("%s/%s" % (prefix, int(length, 16))))
>>> a='\x008*\x00\x0e\xe2\xf1\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
>>> import struct
>>> DecodeIPv6Prefix(a)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<stdin>", line 3, in DecodeIPv6Prefix
ValueError: zero length field name in format
>>> addr = a + b'\x00' * (18-len(a))
>>> map('{:x}'.format, struct.unpack('!BB'+'H'*8, addr))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: zero length field name in format
>>> map('{0:x}'.format, struct.unpack('!BB'+'H'*8, addr))
['0', '38', '2a00', 'ee2', 'f100', '0', '0', '0', '0', '0']
>>> from netaddr import IPNetwork
>>> DecodeIPv6Prefix(a)
'2a00:ee2:f100::/56'
```