### PR TITLE
Fix IDE incorrectly warning about AuthPacket methods after CreateAuthPacket

### DIFF
--- a/pyrad/client.py
+++ b/pyrad/client.py
@@ -86,7 +86,7 @@ class Client(host.Host):
         dictionary and secret used for the client.
 
         :return: a new empty packet instance
-        :rtype:  pyrad.packet.Packet
+        :rtype:  pyrad.packet.AuthPacket
         """
         return host.Host.CreateAuthPacket(self, secret=self.secret, **args)
 

--- a/pyrad/tests/testPacket.py
+++ b/pyrad/tests/testPacket.py
@@ -192,8 +192,8 @@ class PacketTests(unittest.TestCase):
                 six.b('\x01\x05one\x01\x05two\x01\x07three'))
 
         self.packet.clear()
-        self.packet[1] = [six.b('value')]
         self.packet[(1, 2)] = [six.b('value')]
+        self.packet[1] = [six.b('value')]
         self.assertEqual(
                 self.packet._PktEncodeAttributes(),
                 six.b('\x1a\x0d\x00\x00\x00\x01\x02\x07value\x01\x07value'))


### PR DESCRIPTION
IDEs which respect the rtype of functions as declared in their docstrings (such as PyCharm) will complain about calling AuthPacket methods such as PwCrypt on the result of a Client.CreateAuthPacket, because its rtype is given as pyrad.packet.Packet.

This updates the docstring in Client.CreateAuthPacket to the correct rtype (from Packet to AuthPacket) which allows these methods to be used as expected.