### PR TITLE
Issue 68 and 70 - Update testPktEncodeAttributes to make it pass in 3.6

### DIFF
--- a/pyrad/tests/testPacket.py
+++ b/pyrad/tests/testPacket.py
@@ -192,8 +192,8 @@ class PacketTests(unittest.TestCase):
                 six.b('\x01\x05one\x01\x05two\x01\x07three'))
 
         self.packet.clear()
-        self.packet[1] = [six.b('value')]
         self.packet[(1, 2)] = [six.b('value')]
+        self.packet[1] = [six.b('value')]
         self.assertEqual(
                 self.packet._PktEncodeAttributes(),
                 six.b('\x1a\x0d\x00\x00\x00\x01\x02\x07value\x01\x07value'))


### PR DESCRIPTION
This test failed in python 3.6 because after 3.5 dictionaries remember the order in which their items were added. See e.g. https://stackoverflow.com/questions/39980323/are-dictionaries-ordered-in-python-3-6 for more information.

The easiest fix is just to change the order that items are added in the test case, which makes tests pass again on my 3.6 CPython (and also doesn't break running this test in versions prior to 3.6).

This should close https://github.com/wichert/pyrad/issues/68 and https://github.com/wichert/pyrad/issues/70