### PR TITLE
Issue 83 - Correct rtype in docstring for Client.CreateAuthPacket

### DIFF
--- a/pyrad/client.py
+++ b/pyrad/client.py
@@ -86,7 +86,7 @@ class Client(host.Host):
         dictionary and secret used for the client.
 
         :return: a new empty packet instance
-        :rtype:  pyrad.packet.Packet
+        :rtype:  pyrad.packet.AuthPacket
         """
         return host.Host.CreateAuthPacket(self, secret=self.secret, **args)
 


### PR DESCRIPTION
The rtype in the docstring of `Client.CreateAuthPacket` is incorrectly given as `pyrad.packet.Packet`.

IDEs which respect the rtype of functions as declared in their docstrings (such as PyCharm) will complain about calling `AuthPacket` methods such as `PwCrypt` on the result of `Client.CreateAuthPacket` because of this rtype.

This PR updates the docstring in `Client.CreateAuthPacket` to the correct rtype (from `Packet` to `AuthPacket`) which allows these methods to be used as expected. Closes https://github.com/wichert/pyrad/issues/83.