### PR TITLE
Changed to allow IP ranges to be specified.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.idea/
+DS_Store/
 build/
 dist/
 docs/.build/


### PR DESCRIPTION
Useful when client IP addresses may not be known but are within a network range such as the case when using auto scaling load balancers.

To use, simply specify the RemoteHost address as a CIDR.

For example:

hosts={
    'internal': server.RemoteHost('192.168.0.0/24', 'Kah3choteereethiejeimaeziecumi', 'internal'),
    'localnet': server.RemoteHost('10.0.0.0/18', 'Kah3choteereethiejeimaeziecumi', 'localnet'),
    'allhosts': server.RemoteHost('0/0', 'Kah3choteereethiejeimaeziecumi', 'default'),
    'onehost': server.RemoteHost('10.0.0.1', 'Kah3choteereethiejeimaeziecumi', 'onehost'),
}