### PR TITLE
Fix of accounting request verification

### DIFF
--- a/pyrad/packet.py
+++ b/pyrad/packet.py
@@ -661,7 +661,7 @@ class AcctPacket(Packet):
     def VerifyAcctRequest(self):
         """Verify request authenticator.
 
-        :return: True if verification failed else False
+        :return: False if verification failed else True
         :rtype: boolean
         """
         assert(self.raw_packet)

--- a/pyrad/server_async.py
+++ b/pyrad/server_async.py
@@ -81,7 +81,7 @@ class DatagramProtocolServer(asyncio.Protocol):
                                  dict=self.server.dict,
                                  packet=data)
                 if self.server.enable_pkt_verify:
-                    if req.VerifyAuthRequest():
+                    if not req.VerifyAuthRequest():
                         raise PacketError('Packet verification failed')
 
             elif self.server_type == ServerType.Coa:
@@ -91,7 +91,7 @@ class DatagramProtocolServer(asyncio.Protocol):
                                 dict=self.server.dict,
                                 packet=data)
                 if self.server.enable_pkt_verify:
-                    if req.VerifyCoARequest():
+                    if not req.VerifyCoARequest():
                         raise PacketError('Packet verification failed')
 
             elif self.server_type == ServerType.Acct:
@@ -102,7 +102,7 @@ class DatagramProtocolServer(asyncio.Protocol):
                                  dict=self.server.dict,
                                  packet=data)
                 if self.server.enable_pkt_verify:
-                    if req.VerifyAcctRequest():
+                    if not req.VerifyAcctRequest():
                         raise PacketError('Packet verification failed')
 
             # Call request callback

--- a/pyrad/server_async.py
+++ b/pyrad/server_async.py
@@ -102,7 +102,7 @@ class DatagramProtocolServer(asyncio.Protocol):
                                  dict=self.server.dict,
                                  packet=data)
                 if self.server.enable_pkt_verify:
-                    if req.VerifyAcctRequest():
+                    if not req.VerifyAcctRequest():
                         raise PacketError('Packet verification failed')
 
             # Call request callback

--- a/pyrad/server_async.py
+++ b/pyrad/server_async.py
@@ -81,7 +81,7 @@ class DatagramProtocolServer(asyncio.Protocol):
                                  dict=self.server.dict,
                                  packet=data)
                 if self.server.enable_pkt_verify:
-                    if not req.VerifyAuthRequest():
+                    if req.VerifyAuthRequest():
                         raise PacketError('Packet verification failed')
 
             elif self.server_type == ServerType.Coa:
@@ -91,7 +91,7 @@ class DatagramProtocolServer(asyncio.Protocol):
                                 dict=self.server.dict,
                                 packet=data)
                 if self.server.enable_pkt_verify:
-                    if not req.VerifyCoARequest():
+                    if req.VerifyCoARequest():
                         raise PacketError('Packet verification failed')
 
             elif self.server_type == ServerType.Acct:
@@ -102,7 +102,7 @@ class DatagramProtocolServer(asyncio.Protocol):
                                  dict=self.server.dict,
                                  packet=data)
                 if self.server.enable_pkt_verify:
-                    if not req.VerifyAcctRequest():
+                    if req.VerifyAcctRequest():
                         raise PacketError('Packet verification failed')
 
             # Call request callback


### PR DESCRIPTION
From rfc 2866.

> 3.  Packet Format
> ......
>  Request Authenticator
> 
>       In Accounting-Request Packets, the Authenticator value is a 16
>       octet MD5 [5] checksum, called the Request Authenticator.
> 
>       The NAS and RADIUS accounting server share a secret.  The Request
>       Authenticator field in Accounting-Request packets contains a one-
>       way MD5 hash calculated over a stream of octets consisting of the
>       Code + Identifier + Length + 16 zero octets + request attributes +
>       shared secret (where + indicates concatenation).  The 16 octet MD5
>       hash value is stored in the Authenticator field of the
>       Accounting-Request packet.
> 
>       Note that the Request Authenticator of an Accounting-Request can
>       not be done the same way as the Request Authenticator of a RADIUS
>       Access-Request, because there is no User-Password attribute in an
>       Accounting-Request.

